### PR TITLE
Add Address Entity, Controller, Service, Repository

### DIFF
--- a/src/main/kotlin/techcourse/herobeans/configuration/WebMvcConfigurer.kt
+++ b/src/main/kotlin/techcourse/herobeans/configuration/WebMvcConfigurer.kt
@@ -18,6 +18,7 @@ class WebMvcConfigurer(
                 "/api/admin/**",
                 "api/admin/stats/**",
                 "/api/payments/**",
+                "/api/address/**",
             )
     }
 

--- a/src/main/kotlin/techcourse/herobeans/controller/AddressController.kt
+++ b/src/main/kotlin/techcourse/herobeans/controller/AddressController.kt
@@ -18,7 +18,7 @@ import techcourse.herobeans.dto.UpdateAddressRequest
 import techcourse.herobeans.service.AddressService
 
 @RestController
-@RequestMapping("/api/address") // TODO: add to interceptor
+@RequestMapping("/api/address")
 class AddressController(
     private val addressService: AddressService,
 ) {
@@ -42,9 +42,9 @@ class AddressController(
 
     @PatchMapping("/{addressId}")
     fun updateAddress(
+        @LoginMember member: MemberDto,
         @RequestBody request: UpdateAddressRequest,
         @PathVariable addressId: Long,
-        @LoginMember member: MemberDto,
     ): ResponseEntity<AddressDto> {
         val updatedAddress = addressService.updateAddress(addressId, member.id!!, request)
         return ResponseEntity.ok(updatedAddress)

--- a/src/main/kotlin/techcourse/herobeans/controller/AddressController.kt
+++ b/src/main/kotlin/techcourse/herobeans/controller/AddressController.kt
@@ -1,0 +1,60 @@
+package techcourse.herobeans.controller
+
+import ecommerce.annotation.LoginMember
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import techcourse.herobeans.dto.AddressDto
+import techcourse.herobeans.dto.AddressRequest
+import techcourse.herobeans.dto.MemberDto
+import techcourse.herobeans.dto.UpdateAddressRequest
+import techcourse.herobeans.service.AddressService
+
+@RestController
+@RequestMapping("/api/address") // TODO: add to interceptor
+class AddressController(
+    private val addressService: AddressService,
+) {
+    @PostMapping
+    fun createAddress(
+        @LoginMember member: MemberDto,
+        @RequestBody request: AddressRequest,
+    ): ResponseEntity<AddressDto> {
+        val newAddress = addressService.createAddress(request, member.id!!)
+        return ResponseEntity.status(HttpStatus.CREATED).body(newAddress)
+    }
+
+    @DeleteMapping("/{addressId}")
+    fun removeAddress(
+        @LoginMember member: MemberDto,
+        @PathVariable addressId: Long,
+    ): ResponseEntity<Void> {
+        addressService.removeAddress(addressId, member.id!!)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PatchMapping("/{addressId}")
+    fun updateAddress(
+        @RequestBody request: UpdateAddressRequest,
+        @PathVariable addressId: Long,
+        @LoginMember member: MemberDto,
+    ): ResponseEntity<AddressDto> {
+        val updatedAddress = addressService.updateAddress(addressId, member.id!!, request)
+        return ResponseEntity.ok(updatedAddress)
+    }
+
+    @GetMapping()
+    fun getAllAddresses(
+        @LoginMember member: MemberDto,
+    ): ResponseEntity<List<AddressDto>> {
+        val addresses = addressService.getAllAddresses(member.id!!)
+        return ResponseEntity.ok(addresses)
+    }
+}

--- a/src/main/kotlin/techcourse/herobeans/dto/AddressDto.kt
+++ b/src/main/kotlin/techcourse/herobeans/dto/AddressDto.kt
@@ -1,0 +1,11 @@
+package techcourse.herobeans.dto
+
+class AddressDto(
+    val street: String,
+    val number: String,
+    val city: String = "Berlin",
+    val postalCode: String,
+    val countryCode: String = "DE",
+    val label: String? = null,
+    val id: Long = 0L,
+)

--- a/src/main/kotlin/techcourse/herobeans/dto/AddressRequest.kt
+++ b/src/main/kotlin/techcourse/herobeans/dto/AddressRequest.kt
@@ -1,0 +1,22 @@
+package techcourse.herobeans.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+class AddressRequest(
+    @field:NotBlank(message = "Street is required")
+    val street: String,
+    @field:NotBlank(message = "Number is required")
+    val number: String,
+    @field:NotBlank(message = "City is required")
+    val city: String = "Berlin",
+    @field:NotBlank(message = "Postal code is required")
+    @field:Pattern(regexp = "\\d{5}", message = "Postal code must be 5 digits")
+    val postalCode: String,
+    @field:NotBlank(message = "Country is required")
+    val countryCode: String = "DE",
+    @field:Size(max = 20, message = "Label can be at most 20 characters")
+    val label: String? = null,
+    val id: Long = 0L,
+)

--- a/src/main/kotlin/techcourse/herobeans/dto/UpdateAddressRequest.kt
+++ b/src/main/kotlin/techcourse/herobeans/dto/UpdateAddressRequest.kt
@@ -1,0 +1,13 @@
+package techcourse.herobeans.dto
+
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+class UpdateAddressRequest(
+    val street: String? = null,
+    val number: String? = null,
+    @field:Pattern(regexp = "\\d{5}", message = "Postal code must be 5 digits")
+    val postalCode: String? = null,
+    @field:Size(max = 20, message = "Label can be at most 20 characters")
+    val label: String? = null,
+)

--- a/src/main/kotlin/techcourse/herobeans/entity/Address.kt
+++ b/src/main/kotlin/techcourse/herobeans/entity/Address.kt
@@ -14,16 +14,16 @@ import jakarta.persistence.ManyToOne
 @Entity
 class Address(
     @Column(nullable = false)
-    val street: String,
+    var street: String,
     @Column(nullable = false)
-    val number: String,
+    var number: String,
     @Column(nullable = false)
     val city: String = "Berlin",
     @Column(nullable = false)
-    val postalCode: String,
+    var postalCode: String,
     @Column(nullable = false)
     val countryCode: String = "DE",
-    val label: String? = null,
+    var label: String? = null,
     @ManyToOne(fetch = FetchType.LAZY)
     val member: Member,
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/techcourse/herobeans/entity/Address.kt
+++ b/src/main/kotlin/techcourse/herobeans/entity/Address.kt
@@ -31,7 +31,7 @@ class Address(
 ) {
     init {
         require(street.isNotEmpty()) { "Street cannot be empty" }
-        require(number.isNotEmpty()) { "Number cannot be empty and has to contain digits" }
+        require(number.isNotEmpty()) { "Number cannot be empty" }
         require(this.isInBerlin()) { "Out of shipping & billing zone" }
         require(this.isInGermany()) { "Out of shipping & billing zone" }
     }

--- a/src/main/kotlin/techcourse/herobeans/entity/Address.kt
+++ b/src/main/kotlin/techcourse/herobeans/entity/Address.kt
@@ -1,0 +1,48 @@
+package techcourse.herobeans.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+
+/**
+ * label stands for "Home", "Work"
+ */
+@Entity
+class Address(
+    @Column(nullable = false)
+    val street: String,
+    @Column(nullable = false)
+    val number: String,
+    @Column(nullable = false)
+    val city: String = "Berlin",
+    @Column(nullable = false)
+    val postalCode: String,
+    @Column(nullable = false)
+    val countryCode: String = "DE",
+    val label: String? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    val member: Member,
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) {
+    init {
+        require(street.isNotEmpty()) { "Street cannot be empty" }
+        require(number.isNotEmpty()) { "Number cannot be empty and has to contain digits" }
+        require(this.isInBerlin()) { "Out of shipping & billing zone" }
+        require(this.isInGermany()) { "Out of shipping & billing zone" }
+    }
+
+    fun isInBerlin(): Boolean {
+        return this.city.equals("Berlin", ignoreCase = true) ||
+            this.postalCode.startsWith("10") || // Berlin postal codes start with 10xxx or 12xxx
+            this.postalCode.startsWith("12")
+    }
+
+    fun isInGermany(): Boolean {
+        return this.countryCode.equals("DE", ignoreCase = true)
+    }
+}

--- a/src/main/kotlin/techcourse/herobeans/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/techcourse/herobeans/exception/GlobalExceptionHandler.kt
@@ -20,9 +20,21 @@ class GlobalExceptionHandler {
     @ExceptionHandler(
         value = [
             EmailOrPasswordIncorrectException::class,
+            ForbiddenAccessException::class,
         ],
     )
     fun handleForbidden(ex: RuntimeException) = buildErrorResponse(HttpStatus.FORBIDDEN, ex)
+
+    @ExceptionHandler(UnauthorizedAccessException::class)
+    fun handleUnauthorizedException(ex: UnauthorizedAccessException) = buildErrorResponse(HttpStatus.UNAUTHORIZED, ex)
+
+    @ExceptionHandler(NotFoundException::class)
+    fun handleNotFound(ex: NotFoundException) = buildErrorResponse(HttpStatus.NOT_FOUND, ex)
+
+    @ExceptionHandler(
+        value = [MaxAddressesExceededException::class],
+    )
+    fun handleBadRequest(ex: RuntimeException) = buildErrorResponse(HttpStatus.BAD_REQUEST, ex)
 
     fun buildErrorResponse(
         status: HttpStatus,

--- a/src/main/kotlin/techcourse/herobeans/exception/MaxAddressesExceededException.kt
+++ b/src/main/kotlin/techcourse/herobeans/exception/MaxAddressesExceededException.kt
@@ -1,0 +1,3 @@
+package techcourse.herobeans.exception
+
+class MaxAddressesExceededException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/techcourse/herobeans/exception/NotFoundException.kt
+++ b/src/main/kotlin/techcourse/herobeans/exception/NotFoundException.kt
@@ -1,0 +1,3 @@
+package techcourse.herobeans.exception
+
+class NotFoundException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/techcourse/herobeans/mapper/AddressMapper.kt
+++ b/src/main/kotlin/techcourse/herobeans/mapper/AddressMapper.kt
@@ -1,0 +1,44 @@
+package techcourse.herobeans.mapper
+
+import techcourse.herobeans.dto.AddressDto
+import techcourse.herobeans.dto.AddressRequest
+import techcourse.herobeans.entity.Address
+import techcourse.herobeans.entity.Member
+
+object AddressMapper {
+    fun Address.toDto(): AddressDto {
+        return AddressDto(
+            street = this.street,
+            number = this.number,
+            city = this.city,
+            postalCode = this.postalCode,
+            countryCode = this.countryCode,
+            label = this.label,
+            id = this.id,
+        )
+    }
+
+    fun AddressDto.toEntity(member: Member): Address {
+        return Address(
+            street = this.street,
+            number = this.number,
+            city = this.city,
+            postalCode = this.postalCode,
+            countryCode = this.countryCode,
+            label = this.label,
+            member = member,
+        )
+    }
+
+    fun AddressRequest.toEntity(member: Member): Address {
+        return Address(
+            street = this.street,
+            number = this.number,
+            city = this.city,
+            postalCode = this.postalCode,
+            countryCode = this.countryCode,
+            label = this.label,
+            member = member,
+        )
+    }
+}

--- a/src/main/kotlin/techcourse/herobeans/repository/AddressJpaRepository.kt
+++ b/src/main/kotlin/techcourse/herobeans/repository/AddressJpaRepository.kt
@@ -1,0 +1,8 @@
+package techcourse.herobeans.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import techcourse.herobeans.entity.Address
+
+interface AddressJpaRepository : JpaRepository<Address, Long> {
+    fun findAllByMemberId(memberId: Long): List<Address>
+}

--- a/src/main/kotlin/techcourse/herobeans/service/AddressService.kt
+++ b/src/main/kotlin/techcourse/herobeans/service/AddressService.kt
@@ -1,0 +1,64 @@
+package techcourse.herobeans.service
+
+import org.springframework.stereotype.Service
+import techcourse.herobeans.dto.AddressDto
+import techcourse.herobeans.dto.AddressRequest
+import techcourse.herobeans.dto.UpdateAddressRequest
+import techcourse.herobeans.exception.ForbiddenAccessException
+import techcourse.herobeans.exception.MaxAddressesExceededException
+import techcourse.herobeans.exception.NotFoundException
+import techcourse.herobeans.mapper.AddressMapper.toDto
+import techcourse.herobeans.mapper.AddressMapper.toEntity
+import techcourse.herobeans.repository.AddressJpaRepository
+import techcourse.herobeans.repository.MemberJpaRepository
+
+@Service
+class AddressService(
+    private val addressRepository: AddressJpaRepository,
+    private val memberJpaRepository: MemberJpaRepository,
+) {
+    fun createAddress(
+        request: AddressRequest,
+        memberId: Long,
+    ): AddressDto {
+        val member = memberJpaRepository.findById(memberId).orElseThrow { NotFoundException("Member with id: $memberId not found") }
+        if (addressRepository.findAllByMemberId(memberId).size >= 5) {
+            throw MaxAddressesExceededException("Max 5 addresses allowed")
+        }
+        val address = request.toEntity(member)
+        return addressRepository.save(address).toDto()
+    }
+
+    fun removeAddress(
+        id: Long,
+        memberId: Long,
+    ) {
+        val address = addressRepository.findById(id).orElseThrow { NotFoundException("Address with id: $id not found") }
+        if (address.member.id != memberId) {
+            throw ForbiddenAccessException("You are not allowed to delete this address")
+        }
+        addressRepository.delete(address)
+    }
+
+    fun updateAddress(
+        id: Long,
+        memberId: Long,
+        request: UpdateAddressRequest,
+    ): AddressDto {
+        val address = addressRepository.findById(id).orElseThrow { NotFoundException("Address with id: $id not found") }
+        if (address.member.id != memberId) {
+            throw ForbiddenAccessException("You are not allowed to modify this address")
+        }
+
+        request.street?.let { address.street = it }
+        request.number?.let { address.number = it }
+        request.postalCode?.let { address.postalCode = it }
+        request.label?.let { address.label = it }
+
+        return addressRepository.save(address).toDto()
+    }
+
+    fun getAllAddresses(memberId: Long): List<AddressDto> {
+        return addressRepository.findAllByMemberId(memberId).map { it.toDto() }
+    }
+}

--- a/src/main/kotlin/techcourse/herobeans/service/AddressService.kt
+++ b/src/main/kotlin/techcourse/herobeans/service/AddressService.kt
@@ -1,6 +1,7 @@
 package techcourse.herobeans.service
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import techcourse.herobeans.dto.AddressDto
 import techcourse.herobeans.dto.AddressRequest
 import techcourse.herobeans.dto.UpdateAddressRequest
@@ -13,6 +14,7 @@ import techcourse.herobeans.repository.AddressJpaRepository
 import techcourse.herobeans.repository.MemberJpaRepository
 
 @Service
+@Transactional
 class AddressService(
     private val addressRepository: AddressJpaRepository,
     private val memberJpaRepository: MemberJpaRepository,

--- a/src/test/kotlin/techcourse/herobeans/e2e/AddressControllerTest.kt
+++ b/src/test/kotlin/techcourse/herobeans/e2e/AddressControllerTest.kt
@@ -1,0 +1,178 @@
+package techcourse.herobeans.e2e
+
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import io.restassured.response.ExtractableResponse
+import io.restassured.response.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import techcourse.herobeans.dto.AddressDto
+import techcourse.herobeans.dto.AddressRequest
+import techcourse.herobeans.dto.RegistrationRequest
+import techcourse.herobeans.dto.UpdateAddressRequest
+import techcourse.herobeans.repository.AddressJpaRepository
+import techcourse.herobeans.repository.MemberJpaRepository
+import java.awt.List
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AddressControllerTest {
+    @Autowired
+    private lateinit var memberRepository: MemberJpaRepository
+
+    @Autowired
+    private lateinit var addressRepository: AddressJpaRepository
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    val baseUrl get() = "http://localhost:$port"
+
+    private lateinit var token: String
+
+    @BeforeEach
+    fun setUp() {
+        addressRepository.deleteAll()
+        memberRepository.deleteAll()
+
+        val registrationRequest = RegistrationRequest("test", "test@test.com", "12345678")
+        val response =
+            RestAssured.given()
+                .baseUri(baseUrl)
+                .contentType(ContentType.JSON)
+                .body(registrationRequest)
+                .post("/api/members/register")
+                .then()
+                .statusCode(201)
+                .extract()
+
+        token = response.body().jsonPath().getString("token")
+    }
+
+    @Test
+    fun `should create new address`() {
+        val request = AddressRequest("Street 1", "123", "Berlin", "12345", "DE", "Home")
+
+        val addressDto =
+            RestAssured.given()
+                .baseUri(baseUrl)
+                .header("Authorization", "Bearer $token")
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/address")
+                .then()
+                .statusCode(201)
+                .extract()
+                .`as`(AddressDto::class.java)
+
+        assertThat(addressDto.street).isEqualTo("Street 1")
+        assertThat(addressDto.label).isEqualTo("Home")
+    }
+
+    @Test
+    fun `should not create address if member has already 5 addresses`() {
+        val requests =
+            List(6) {
+                AddressRequest("Street 1", "123", "Berlin", "12345", "DE", "Home")
+            }
+        var response: ExtractableResponse<Response>? = null
+        requests.forEach {
+            response =
+                RestAssured.given()
+                    .baseUri(baseUrl)
+                    .header("Authorization", "Bearer $token")
+                    .contentType(ContentType.JSON)
+                    .body(it)
+                    .post("/api/address")
+                    .then()
+                    .extract()
+        }
+
+        assertThat(response?.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value())
+    }
+
+    @Test
+    fun `should get all addresses`() {
+        val request1 = AddressRequest("Street 1", "123", "Berlin", "12345", "DE", "Home")
+        val request2 = AddressRequest("Street 2", "258", "Berlin", "12049", "DE", "Work")
+
+        RestAssured.given().baseUri(
+            baseUrl,
+        ).header("Authorization", "Bearer $token").contentType(ContentType.JSON).body(request1).post("/api/address")
+        RestAssured.given().baseUri(
+            baseUrl,
+        ).header("Authorization", "Bearer $token").contentType(ContentType.JSON).body(request2).post("/api/address")
+
+        val addresses =
+            RestAssured.given()
+                .baseUri(baseUrl)
+                .header("Authorization", "Bearer $token")
+                .get("/api/address")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(Array<AddressDto>::class.java)
+
+        assertThat(addresses.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `should update address`() {
+        val createRequest = AddressRequest("Street 1", "123", "Berlin", "12345", "DE", "Home")
+
+        val addressDto =
+            RestAssured.given()
+                .baseUri(baseUrl)
+                .header("Authorization", "Bearer $token")
+                .contentType(ContentType.JSON)
+                .body(createRequest)
+                .post("/api/address")
+                .then()
+                .statusCode(201)
+                .extract()
+                .`as`(AddressDto::class.java)
+
+        val updateRequest = UpdateAddressRequest(street = "Updated Street")
+
+        val updatedDto =
+            RestAssured.given()
+                .baseUri(baseUrl)
+                .header("Authorization", "Bearer $token")
+                .contentType(ContentType.JSON)
+                .body(updateRequest)
+                .patch("/api/address/${addressDto.id}")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(AddressDto::class.java)
+
+        assertThat(updatedDto.street).isEqualTo("Updated Street")
+    }
+
+    @Test
+    fun `should delete address`() {
+        val createRequest = AddressRequest("Street 1", "123", "Berlin", "12345", "DE", "Home")
+        val addressDto =
+            RestAssured.given()
+                .baseUri(baseUrl)
+                .header("Authorization", "Bearer $token")
+                .contentType(ContentType.JSON)
+                .body(createRequest)
+                .post("/api/address")
+                .then()
+                .statusCode(201)
+                .extract()
+                .`as`(AddressDto::class.java)
+
+        RestAssured.given()
+            .baseUri(baseUrl)
+            .header("Authorization", "Bearer $token")
+            .delete("/api/address/${addressDto.id}")
+            .then()
+            .statusCode(204)
+    }
+}

--- a/src/test/kotlin/techcourse/herobeans/entity/AddressTest.kt
+++ b/src/test/kotlin/techcourse/herobeans/entity/AddressTest.kt
@@ -1,0 +1,93 @@
+package techcourse.herobeans.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class AddressTest {
+    private val member = Member(name = "Test", email = "test@test.com", password = "12345678")
+
+    @Test
+    fun `should create Address with valid data`() {
+        val address =
+            Address(
+                street = "Alexanderplatz",
+                number = "1",
+                postalCode = "10178",
+                member = member,
+            )
+
+        assertThat(address.street).isEqualTo("Alexanderplatz")
+        assertThat(address.number).isEqualTo("1")
+        assertThat(address.city).isEqualTo("Berlin") // default
+        assertThat(address.countryCode).isEqualTo("DE") // default
+        assertThat(address.member).isEqualTo(member)
+        assertThat(address.isInBerlin()).isTrue
+        assertThat(address.isInGermany()).isTrue
+    }
+
+    @Test
+    fun `should throw exception if street is empty`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Address(
+                street = "",
+                number = "1",
+                postalCode = "10178",
+                member = member,
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception if number is empty`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Address(
+                street = "Alexanderplatz",
+                number = "",
+                postalCode = "10178",
+                member = member,
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception if city or postalCode is outside Berlin`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Address(
+                street = "Some Street",
+                number = "10",
+                city = "Munich",
+                postalCode = "80331",
+                member = member,
+            )
+        }
+    }
+
+    @Test
+    fun `should throw exception if country is not DE`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Address(
+                street = "Alexanderplatz",
+                number = "1",
+                postalCode = "10178",
+                member = member,
+                countryCode = "US",
+            )
+        }
+    }
+
+    @Test
+    fun `isInBerlin should return true for Berlin postal codes starting with 10 or 12`() {
+        val addr1 = Address(street = "Street 1", number = "1", postalCode = "10115", member = member)
+        val addr2 = Address(street = "Street 2", number = "2", postalCode = "12345", member = member)
+
+        assertThat(addr1.isInBerlin()).isTrue
+        assertThat(addr2.isInBerlin()).isTrue
+    }
+
+    @Test
+    fun `isInGermany should return true for country code DE`() {
+        val addr = Address(street = "Street 1", number = "1", postalCode = "10115", member = member)
+        assertThat(addr.isInGermany()).isTrue
+    }
+}


### PR DESCRIPTION
# Address

Add Address Entity and Controller, Service, Repository

## Note
  - AuthenticationControllerTest was fixed in PR #45 hat has not been merged yet
  - there might be a conflict with GlobalExceptionHandler of PR #45 when mergeing

## Description

Added Address Entity, Controller, Service, Repository. The thought process designing Address is described on our [wiki](https://github.com/VittorioDeMarzi/hero-beans/wiki/Address). 

A LoginMember can do all CRUD operations.

I have realized that this address topic is huge if we would want to include e.g. precise validation of postal codes, street numbers, etc. or shipping and billing. I have tried to limit this. 

Fixes #47 #19 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- e2e test for the endpoints
- unit tests for the entity

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
  - one test was fixed in another PR that has not been merged yet