### PR TITLE
Fix start.sh

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,8 +17,6 @@ phases:
       - echo "STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}" >> .env
       - echo "STRIPE_PAYMENT_URL=${STRIPE_PAYMENT_URL}" >> .env
       - echo "ACTIVE_PROFILE=${ACTIVE_PROFILE}" >> .env
-      - echo "LIQUIBASE_USER=${LIQUIBASE_USER}" >> .env
-      - echo "LIQUIBASE_PASSWORD=${LIQUIBASE_PASSWORD}" >> .env
       - echo ".env file created:"
 
   build:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Load environment variables from .env
+if [ -f /home/ubuntu/app/.env ]; then
+  export $(grep -v '^#' /home/ubuntu/app/.env | xargs)
+fi
 
+# Ensure logs folder exists
+mkdir -p /home/ubuntu/app/logs
+
+# Find JAR
 JAR_FILE=$(ls /home/ubuntu/app/build/libs/*.jar | head -n 1 || true)
 
 PROFILE="${1:-${SPRING_PROFILES_ACTIVE:-prod}}"
@@ -14,5 +22,9 @@ if [ -z "$JAR_FILE" ]; then
 fi
 
 echo ">>> [ApplicationStart] Starting: $JAR_FILE (profile=${PROFILE})"
-nohup java $JAVA_OPTS -jar "$JAR_FILE" $SPRING_OPTS > /dev/null 2>&1 &
+nohup java $JAVA_OPTS -jar "$JAR_FILE" $SPRING_OPTS > /home/ubuntu/app/logs/app.log 2>&1 &
 
+# Save PID
+echo $! > /home/ubuntu/app/app.pid
+
+echo ">>> [ApplicationStart] Application started with PID $(cat /home/ubuntu/app/app.pid)"


### PR DESCRIPTION
# Title

Change start.sh 
- Loads .env variables so DB credentials are available.
- Creates logs/ folder.
- Redirects all output to logs/app.log (you can monitor with tail -f logs/app.log).
- Saves the process PID to app.pid for easier stopping/checking.

